### PR TITLE
Prepend pyuavcan in source directory to sys.path

### DIFF
--- a/libuavcan/dsdl_compiler/libuavcan_dsdlc
+++ b/libuavcan/dsdl_compiler/libuavcan_dsdlc
@@ -13,8 +13,8 @@ RUNNING_FROM_SRC_DIR = os.path.abspath(__file__).endswith(os.path.join('libuavca
 if RUNNING_FROM_SRC_DIR:
     print('Running from the source directory')
     scriptdir = os.path.dirname(os.path.abspath(__file__))
-    sys.path.append(os.path.join(scriptdir, '..', '..', 'pyuavcan'))
-    sys.path.append(os.path.join(scriptdir))
+    sys.path.insert(0, os.path.join(scriptdir, '..', '..', 'pyuavcan'))
+    sys.path.insert(0, os.path.join(scriptdir))
 
 def configure_logging(verbosity):
     fmt = '%(message)s'


### PR DESCRIPTION
When running from the source directory, libuavcan_dsdlc should
use the version of pyuavcan in the source directory instead of
a globally installed version of pyuavcan.

Fixes UAVCAN/uavcan#18