### PR TITLE
README: Add link to discussion group

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Reference implementation of the [UAVCAN protocol stack](http://uavcan.org/).
 * [Libuavcan overview](http://uavcan.org/Libuavcan)
 * [List of platforms officially supported by libuavcan](http://uavcan.org/List_of_platforms_officially_supported_by_libuavcan)
 * [Libuavcan tutorials](http://uavcan.org/Libuavcan_tutorials)
+* [UAVCAN discussion group](https://groups.google.com/forum/#!forum/uavcan)
 
 ## Library development
 


### PR DESCRIPTION
* Add a link to the discussion group so people know where to ask
  questions.  This wasn't immediately apparent to me.
* Debated putting it under documentation, but felt weird.