### PR TITLE
libuavcan: Disable Frame Listener with UAVCAN_TINY

### DIFF
--- a/libuavcan/include/uavcan/node/abstract_node.hpp
+++ b/libuavcan/include/uavcan/node/abstract_node.hpp
@@ -115,12 +115,14 @@ public:
         return getDispatcher().getCanIOManager().send(frame, tx_deadline, MonotonicTime(), iface_mask, qos, flags);
     }
 
+#if !UAVCAN_TINY
     /**
      * The @ref IRxFrameListener interface allows one to monitor all incoming CAN frames.
      * This feature can be used to implement multithreaded nodes, or to add secondary protocol support.
      */
     void removeRxFrameListener()                       { getDispatcher().removeRxFrameListener(); }
     void installRxFrameListener(IRxFrameListener* lst) { getDispatcher().installRxFrameListener(lst); }
+#endif
 };
 
 }


### PR DESCRIPTION
* Compliation will fail on small systems with UAVCAN_TINY defined
  with the following error:

      abstract_node.hpp:123:33: error: 'IRxFrameListener' has not been declared

* Resolve issue by removing unecessary functions.
* Error is revealed and resolved when building test_stm32f107.